### PR TITLE
feat: 게시글 보기/불러오기 구현

### DIFF
--- a/lib/pages/ProductDetailPage.dart
+++ b/lib/pages/ProductDetailPage.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:intl/intl.dart';
+
+class ProductDetailPage extends StatelessWidget {
+  final String postId;
+
+  ProductDetailPage({required this.postId});
+
+  Future<Map<String, dynamic>> fetchPostDetails(String postId) async {
+    // Firestore에서 해당 postId로 데이터를 가져오는 예시입니다.
+    DocumentSnapshot doc = await FirebaseFirestore.instance.collection('products').doc(postId).get();
+    return doc.data() as Map<String, dynamic>;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Product Details'),
+      ),
+      body: FutureBuilder<Map<String, dynamic>>(
+        future: fetchPostDetails(postId),
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return Center(child: CircularProgressIndicator());
+          } else if (snapshot.hasError) {
+            return Center(child: Text('Error: ${snapshot.error}'));
+          } else if (!snapshot.hasData || snapshot.data!.isEmpty) {
+            return Center(child: Text('No data found'));
+          } else {
+            Map<String, dynamic> data = snapshot.data!;
+            String postName = data['postName'];
+            String userName = data['userName'];
+            Timestamp timestamp = data['timestamp'];
+            String formattedDate = DateFormat('yyyy-MM-dd').format(timestamp.toDate());
+            String price = data['productPrice'];
+            String description = data['postDescription'];
+            String university = data['University'];
+            List<dynamic> imageUrls = data['imageUrls'];
+
+            return Padding(
+              padding: EdgeInsets.all(16.0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  if (imageUrls.isNotEmpty)
+                    SizedBox(
+                      height: 200,
+                      child: ListView.builder(
+                        scrollDirection: Axis.horizontal,
+                        itemCount: imageUrls.length,
+                        itemBuilder: (context, index) {
+                          return Padding(
+                            padding: const EdgeInsets.only(right: 8.0),
+                            child: Image.network(
+                              imageUrls[index],
+                              width: 200,
+                              height: 200,
+                              fit: BoxFit.cover,
+                              errorBuilder: (context, error, stackTrace) {
+                                return Icon(Icons.error);
+                              },
+                            ),
+                          );
+                        },
+                      ),
+                    ),
+                  SizedBox(height: 16.0),
+                  Text(
+                    postName,
+                    style: TextStyle(fontSize: 24.0, fontWeight: FontWeight.bold),
+                  ),
+                  SizedBox(height: 8.0),
+                  Text('by $userName'),
+                  SizedBox(height: 8.0),
+                  Text(formattedDate),
+                  SizedBox(height: 16.0),
+                  Text('Price: $price'),
+                  SizedBox(height: 16.0),
+                  Text(description),
+                  SizedBox(height: 16.0),
+                  Text('University: $university'),
+                ],
+              ),
+            );
+          }
+        },
+      ),
+    );
+  }
+}

--- a/lib/pages/ProductListPage.dart
+++ b/lib/pages/ProductListPage.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:intl/intl.dart';
 
+import 'ProductDetailPage.dart';
+
 class ProductListPage extends StatefulWidget {
   @override
   _ProductListPageState createState() => _ProductListPageState();
@@ -34,7 +36,7 @@ class _ProductListPageState extends State<ProductListPage> {
             itemBuilder: (context, index) {
               final doc = snapshot.data!.docs[index];
               final data = doc.data() as Map<String, dynamic>;
-              final String postname = data['postname'] ?? 'No title';
+              final String postname = data['postName'] ?? 'No title';
               final String userName = data['userName'] ?? 'Unknown';
               final Timestamp timestamp = data['timestamp'] ?? Timestamp.now();
               final String formattedDate = DateFormat('yyyy-MM-dd').format(timestamp.toDate());
@@ -57,7 +59,14 @@ class _ProductListPageState extends State<ProductListPage> {
                   subtitle: Text('by $userName\n$formattedDate'),
                   isThreeLine: true,
                   onTap: () {
-                    // 게시물 상세 페이지로 이동하는 코드 추가 가능
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => ProductDetailPage(
+                          postId: doc.id,
+                        ),
+                      ),
+                    );
                   },
                 ),
               );

--- a/lib/pages/ProductRegisterPage.dart
+++ b/lib/pages/ProductRegisterPage.dart
@@ -13,9 +13,9 @@ class ProductRegisterPage extends StatefulWidget {
 
 class _ProductRegisterState extends State<ProductRegisterPage> {
   final FirebaseFirestore _firestore = FirebaseFirestore.instance;
-  final TextEditingController _postnameController = TextEditingController();
-  final TextEditingController _postnaeyongController = TextEditingController();
-  final TextEditingController _productpriceController = TextEditingController();
+  final TextEditingController _postNameController = TextEditingController();
+  final TextEditingController _postDescriptionController = TextEditingController();
+  final TextEditingController _productPriceController = TextEditingController();
   List<XFile?> _selectedImages = [];
   List<String?> _imageUrls = [];
   final _imagePicker = ImagePicker();
@@ -85,15 +85,15 @@ class _ProductRegisterState extends State<ProductRegisterPage> {
           child: Column(
             children: [
               TextField(
-                controller: _postnameController,
+                controller: _postNameController,
                 decoration: InputDecoration(labelText: '게시글 제목'),
               ),
               TextField(
-                  controller: _postnaeyongController,
+                  controller: _postDescriptionController,
                   decoration: InputDecoration(labelText: '게시글 내용'),
                   maxLines: 10),
               TextField(
-                controller: _productpriceController,
+                controller: _productPriceController,
                 decoration: InputDecoration(labelText: '가격'),
               ),
               ElevatedButton(
@@ -139,12 +139,12 @@ class _ProductRegisterState extends State<ProductRegisterPage> {
       if (user != null) {
         final imageUrls = await _uploadImagesToFirebase();
         await _firestore.collection('products').add({
-          'postname': _postnameController.text,
-          'postnaeyong': _postnaeyongController.text,
-          'productprice': _productpriceController.text,
+          'postName': _postNameController.text,
+          'postDescription': _postDescriptionController.text,
+          'productPrice': _productPriceController.text,
           'userId': user.uid,
           'userName': userName,
-          'userUniversity': userUniversity,
+          'University': userUniversity,
           'imageUrls': imageUrls,
           'timestamp': FieldValue.serverTimestamp(),
         });
@@ -159,9 +159,9 @@ class _ProductRegisterState extends State<ProductRegisterPage> {
   }
 
   void _clearForm() {
-    _postnameController.clear();
-    _postnaeyongController.clear();
-    _productpriceController.clear();
+    _postNameController.clear();
+    _postDescriptionController.clear();
+    _productPriceController.clear();
     setState(() {
       _selectedImages = [];
       _imageUrls = [];


### PR DESCRIPTION

# 작업 내용
게시글 보기/불러오기 기능을 구현.
구현하면서 게시글 등록의 데이터베이스 저장 속성 이름을 좀 더 명확하게 변경했습니다.

윈도우/ 웹/ 안드로이드 환경에서 테스트 했습니다.


# 발견된 문제
현재 이미지 로딩이 제법 걸리는 문제가 보입니다.(이미지 크기 문제인듯)
이미지 크기를 최적화 하는 방식, 이미지 캐싱 방식을 도입할지 고민입니다.

현재 이미지를 포함한 게시글을 등록할때 시간이 오래걸립니다.
게시글을 등록할때 비동기 처리로 변경할까 고민입니다.

위는 성능 개선이기에 기능적 문제를 전부 해결하고 수정하는 방향으로 갑시다.