### PR TITLE
채팅방 삭제가 생각보다 많은 작업을 요구했다면 믿어주시겠습니까

### DIFF
--- a/lib/Service/FirebaseService.dart
+++ b/lib/Service/FirebaseService.dart
@@ -118,46 +118,107 @@ class FirebaseService {
     final data = await json.decode(response);
     return data['fcm_url'];
   }
+
   Future<String> getVapidKey() async {
     final String response = await rootBundle.loadString('assets/secret.json');
     final data = await json.decode(response);
     return data['vapid_key'];
   }
 
-  Future<String> createChatRoom(String otherUserId,String productId, String roomName ) async {
+  Future<String> createChatRoom(String otherUserId, String productId, String roomName) async {
     String userId = FirebaseAuth.instance.currentUser!.uid;
-    DocumentReference docRef = await FirebaseFirestore.instance.collection('chat_rooms').add({
+
+    // 1. 채팅방 문서 생성
+    DocumentReference chatRoomRef = await FirebaseFirestore.instance.collection('chat_rooms').add({
       'name': roomName,
       'last_updated': FieldValue.serverTimestamp(),
-      'members': [userId, otherUserId], // 현재 사용자 ID와 상대방의 ID 추가
       'product_id': productId,
     });
-    return docRef.id;
+
+    // 2. 참여자 문서 생성
+    await FirebaseFirestore.instance.collection('chat_participants').doc('${chatRoomRef.id}-$userId').set({
+      'product_id': productId,
+      'room_id': chatRoomRef.id,
+      'user_id': userId,
+      'joined_at': FieldValue.serverTimestamp(),
+      'left_at': null,
+    });
+
+    await FirebaseFirestore.instance.collection('chat_participants').doc('${chatRoomRef.id}-$otherUserId').set({
+      'product_id': productId,
+      'room_id': chatRoomRef.id,
+      'user_id': otherUserId,
+      'joined_at': FieldValue.serverTimestamp(),
+      'left_at': null,
+    });
+
+    return chatRoomRef.id;
   }
 
-  Future<void> deleteChat(String chatRoomId) async {
+
+  Future<void> leaveChatRoom(String chatRoomId) async {
     String userId = FirebaseAuth.instance.currentUser!.uid;
-    await FirebaseFirestore.instance.collection('chat_rooms')
-        .doc(chatRoomId)
+
+    // 1. 참여자 문서 업데이트
+    await FirebaseFirestore.instance.collection('chat_participants')
+        .doc('$chatRoomId-$userId')
         .update({
-      'deleted_by': FieldValue.arrayUnion([userId])
+      'left_at': FieldValue.serverTimestamp(),
     });
   }
 
+  Future<void> rejoinChatRoom(String chatRoomId) async {
+    String userId = FirebaseAuth.instance.currentUser!.uid;
 
-  Future<String?> findExistingChatRoom(String productId, String userId) async {
-    final querySnapshot = await FirebaseFirestore.instance
-        .collection('chat_rooms')
-        .where('product_id', isEqualTo: productId)
-        .where('members', arrayContains: userId)
-        .limit(1)
+    // 1. 참여자 문서 확인
+    DocumentSnapshot participantDoc = await FirebaseFirestore.instance
+        .collection('chat_participants')
+        .doc('$chatRoomId-$userId')
         .get();
 
-    if (querySnapshot.docs.isNotEmpty) {
-      return querySnapshot.docs.first.id; // Return the ID of the existing chat room
+    if (!participantDoc.exists || participantDoc['left_at'] != null) {
+      // 2. 채팅방 참여
+      await FirebaseFirestore.instance.collection('chat_participants')
+          .doc('$chatRoomId-$userId')
+          .set({
+        'userId': userId,
+        'joined_at': FieldValue.serverTimestamp(),
+        'left_at': null,
+      });
     }
-    return null; // No existing chat room found
   }
+
+  Future<String?> getExistingChatRoomId(String otherUserId, String productId) async {
+    String userId = FirebaseAuth.instance.currentUser!.uid;
+
+    // 1. 사용자와 특정 제품에 대한 모든 채팅방 조회
+    QuerySnapshot userChatRoomsSnapshot = await FirebaseFirestore.instance
+        .collection('chat_participants')
+        .where('user_id', isEqualTo: userId)
+        .where('product_id', isEqualTo: productId)
+        .get();
+
+    for (QueryDocumentSnapshot userChatDoc in userChatRoomsSnapshot.docs) {
+      String chatRoomId = userChatDoc['room_id'];
+
+      // 2. 해당 채팅방에 다른 사용자가 참여하고 있는지 확인
+      QuerySnapshot otherUserChatRoomsSnapshot = await FirebaseFirestore.instance
+          .collection('chat_participants')
+          .where('room_id', isEqualTo: chatRoomId)
+          .where('user_id', isEqualTo: otherUserId)
+          .get();
+
+      if (otherUserChatRoomsSnapshot.docs.isNotEmpty) {
+        print('Existing chat room found: $chatRoomId');
+        return chatRoomId;
+      }
+    }
+
+    // 해당 조건을 만족하는 채팅방이 없는 경우 null 반환
+    print('No existing chat room found');
+    return null;
+  }
+
 
 
 }

--- a/lib/pages/ChatRoomsPage.dart
+++ b/lib/pages/ChatRoomsPage.dart
@@ -1,10 +1,16 @@
-import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
 import 'ChatPage.dart';
 
-class ChatRoomsPage extends StatelessWidget {
-  final String userId = FirebaseAuth.instance.currentUser!.uid;
+class ChatRoomsPage extends StatefulWidget {
+  @override
+  _ChatRoomsPageState createState() => _ChatRoomsPageState();
+}
+
+class _ChatRoomsPageState extends State<ChatRoomsPage> {
+  final FirebaseAuth _auth = FirebaseAuth.instance;
+  final FirebaseFirestore _firestore = FirebaseFirestore.instance;
 
   @override
   Widget build(BuildContext context) {
@@ -12,30 +18,72 @@ class ChatRoomsPage extends StatelessWidget {
       appBar: AppBar(
         title: Text('Chat Rooms'),
       ),
-      body: StreamBuilder(
-        stream: FirebaseFirestore.instance
-            .collection('chat_rooms')
-            .where('members', arrayContains: userId)
-            .where('deleted_by', whereNotIn: [userId])
+      body: StreamBuilder<QuerySnapshot>(
+        stream: _firestore
+            .collection('chat_participants')
+            .where('user_id', isEqualTo: _auth.currentUser!.uid)
+            .where('left_at', isNull: true)
             .snapshots(),
-        builder: (context, AsyncSnapshot<QuerySnapshot> snapshot) {
-          if (!snapshot.hasData) {
-            return Center(child: CircularProgressIndicator());
+        builder: (context, snapshot) {
+          if (snapshot.hasError) {
+            return Center(
+              child: Text('Something went wrong'),
+            );
           }
-          var chatRooms = snapshot.data!.docs;
+
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return Center(
+              child: CircularProgressIndicator(),
+            );
+          }
+
+          if (snapshot.data!.docs.isEmpty) {
+            return Center(
+              child: Text('No chat rooms found'),
+            );
+          }
+
           return ListView.builder(
-            itemCount: chatRooms.length,
+            itemCount: snapshot.data!.docs.length,
             itemBuilder: (context, index) {
-              var chatRoom = chatRooms[index];
-              return ListTile(
-                title: Text(chatRoom['name']),
-                onTap: () {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (context) => ChatPage(chatRoom.id),
-                    ),
-                  );
+              DocumentSnapshot document = snapshot.data!.docs[index];
+              String chatRoomId = document['room_id'];
+
+              // 채팅방 이름을 가져오기 위해 채팅방 문서 조회
+              return FutureBuilder<DocumentSnapshot>(
+                future: _firestore.collection('chat_rooms').doc(chatRoomId).get(),
+                builder: (context, chatRoomSnapshot) {
+                  if (chatRoomSnapshot.hasError) {
+                    return ListTile(
+                      title: Text('Error loading chat room name'),
+                    );
+                  }
+
+                  if (chatRoomSnapshot.connectionState == ConnectionState.waiting) {
+                    return ListTile(
+                      title: Text('Loading chat room name...'),
+                    );
+                  }
+
+                  if (chatRoomSnapshot.data != null) {
+                    String chatRoomName = chatRoomSnapshot.data!['name'];
+                    return ListTile(
+                      title: Text(chatRoomName),
+                      onTap: () {
+                        // Navigate to the chat room page
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) => ChatPage(chatRoomId),
+                          ),
+                        );
+                      },
+                    );
+                  } else {
+                    return ListTile(
+                      title: Text('Chat room name not found'),
+                    );
+                  }
                 },
               );
             },

--- a/lib/pages/ProductDetailPage.dart
+++ b/lib/pages/ProductDetailPage.dart
@@ -303,7 +303,7 @@ class ProductDetailPage extends StatelessWidget {
                             child: BtnYesBG(
                               btnText: "채팅하기",
                               onPressed: () async {
-                                if(postUserId == user!.uid){
+                                if(postUserId == user!.uid){ // 본인 게시물인 경우
                                   ScaffoldMessenger.of(context).showSnackBar(
                                     SnackBar(content: Text('본인 게시물입니다.')),
                                   );
@@ -311,12 +311,13 @@ class ProductDetailPage extends StatelessWidget {
                                 }
                                 // Check for an existing chat room
                                 String? existingChatId = await FirebaseService()
-                                    .findExistingChatRoom(postId, user!.uid);
+                                    .getExistingChatRoomId(postUserId, postId);
 
                                 String chatId;
                                 if (existingChatId != null) {
                                   // Use the existing chat room
                                   chatId = existingChatId;
+                                  await FirebaseService().rejoinChatRoom(chatId);//채팅방 재참여
                                 } else {
                                   // No existing chat room found, create a new one
                                   chatId = await FirebaseService()


### PR DESCRIPTION
채팅방 생성 테이블이 변경됐습니다.
이제 채팅방 테이블과 채팅방 참석 인원 테이블이 남는다.
채팅방 삭제는 FirebaseService().leaveChatRoom(방 id) 로 실행합니다.
채팅방 중복 알고리즘도 변경했습니다. 
파이어베이스 요청 수 최적화를 했습니다.