### PR TITLE
feat:제품목록페이지 UI 작업

### DIFF
--- a/lib/pages/ProductListPage.dart
+++ b/lib/pages/ProductListPage.dart
@@ -76,8 +76,15 @@ class _ProductListPageState extends State<ProductListPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      backgroundColor: Colors.white,
       appBar: AppBar(
+        backgroundColor: Colors.white,
         title: Text('상품 목록'),
+        actions: [
+
+          IconButton(onPressed: () => {print("알림버튼 클릭")}, icon: Icon(Icons.notifications_rounded), color: Color(0xff4EBDBD),),
+
+        ],
         bottom: PreferredSize(
           preferredSize: Size.fromHeight(48.0),
           child: Row(
@@ -111,85 +118,150 @@ class _ProductListPageState extends State<ProductListPage> {
           ),
         ),
       ),
-      body: StreamBuilder<QuerySnapshot>(
-        stream: _firestore
-            .collection('products')
-            .orderBy('timestamp', descending: true)
-            .snapshots(),
-        builder: (context, snapshot) {
-          if (snapshot.connectionState == ConnectionState.waiting) {
-            return Center(child: CircularProgressIndicator());
-          }
-          if (snapshot.hasError) {
-            return Center(child: Text('Error: ${snapshot.error}'));
-          }
-          if (!snapshot.hasData || snapshot.data!.docs.isEmpty) {
-            return Center(child: Text('No products found.'));
-          }
+      body: Column(
+        children: <Widget>[
 
-          final filteredDocs = snapshot.data!.docs.where((doc) {
-            final data = doc.data() as Map<String, dynamic>;
-            final String postName = data['postName'] ?? 'No title';
-            final String category = data['category'] ?? '';
+          // 검색 필드 공간
+          Container(
+            decoration: BoxDecoration(
+              color: Colors.white,
+              border: Border.all(
+                color: Color(0xff4EBDBD),
+                width: 1.0,
+              ),
+              borderRadius: BorderRadius.circular(8.0),
+            ),
+            padding: EdgeInsets.symmetric(horizontal: 12.0),
+            child: Row(
+              children: [
+                Icon(Icons.search, color: Color(0xff4EBDBD)),
+                SizedBox(width: 8.0),
+                Expanded(
+                  child: TextField(
+                    decoration: InputDecoration(
+                      labelText: '목록 검색',
+                      border: InputBorder.none,
+                      labelStyle: TextStyle(color: Color(0xff4EBDBD)),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
 
-            final matchesSearchText = _searchText == null ||
-                _searchText!.isEmpty ||
-                postName.toLowerCase().contains(_searchText!.toLowerCase());
-            final matchesCategory = _selectedCategory == null ||
-                _selectedCategory!.isEmpty ||
-                category == _selectedCategory;
+          // 검색 필터, 글쓰기 버튼 공간
+          Row(
 
-            return matchesSearchText && matchesCategory;
-          }).toList();
+            children: [
 
-          if (filteredDocs.isEmpty) {
-            return Center(child: Text('검색하신 내용에 맞는 상품이없어용'));
-          }
-          return ListView.builder(
-            itemCount: filteredDocs.length,
-            itemBuilder: (context, index) {
-              final doc = filteredDocs[index];
-              final data = doc.data() as Map<String, dynamic>;
-              final String postname = data['postName'] ?? 'No title';
-              final String userName = data['userName'] ?? 'Unknown';
-              final String category = data['category'] ?? 'No category';
-              final Timestamp timestamp = data['timestamp'] ?? Timestamp.now();
-              final String formattedDate =
-                  DateFormat('yyyy-MM-dd').format(timestamp.toDate());
-              final List<dynamic> imageUrls = data['imageUrls'] ?? [];
+              //검색필터 공간
+              Expanded(
+                flex: 2,
+                child: Container(
 
-              return Card(
-                child: ListTile(
-                  leading: imageUrls.isNotEmpty
-                      ? Image.network(
-                          imageUrls[0],
-                          width: 50,
-                          height: 50,
-                          fit: BoxFit.cover,
-                          errorBuilder: (context, error, stackTrace) {
-                            return Icon(Icons.error);
-                          },
-                        )
-                      : null,
-                  title: Text(postname),
-                  subtitle:
-                      Text('by $userName\n$formattedDate\n카테고리 : $category'),
-                  isThreeLine: true,
-                  onTap: () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: (context) => ProductDetailPage(
-                          postId: doc.id,
-                        ),
+                ),
+
+              ),
+
+              //글쓰기 버튼 공간
+              Expanded(
+                flex: 1,
+                child: Container(
+
+                ),
+
+              ),
+            ],
+
+          ),
+
+
+
+          Expanded(
+            child: StreamBuilder<QuerySnapshot>(
+              stream: _firestore
+                  .collection('products')
+                  .orderBy('timestamp', descending: true)
+                  .snapshots(),
+              builder: (context, snapshot) {
+                if (snapshot.connectionState == ConnectionState.waiting) {
+                  return Center(child: CircularProgressIndicator());
+                }
+                if (snapshot.hasError) {
+                  return Center(child: Text('Error: ${snapshot.error}'));
+                }
+                if (!snapshot.hasData || snapshot.data!.docs.isEmpty) {
+                  return Center(child: Text('No products found.'));
+                }
+
+                final filteredDocs = snapshot.data!.docs.where((doc) {
+                  final data = doc.data() as Map<String, dynamic>;
+                  final String postName = data['postName'] ?? 'No title';
+                  final String category = data['category'] ?? '';
+
+                  final matchesSearchText = _searchText == null ||
+                      _searchText!.isEmpty ||
+                      postName.toLowerCase().contains(_searchText!.toLowerCase());
+                  final matchesCategory = _selectedCategory == null ||
+                      _selectedCategory!.isEmpty ||
+                      category == _selectedCategory;
+
+                  return matchesSearchText && matchesCategory;
+                }).toList();
+
+                if (filteredDocs.isEmpty) {
+                  return Center(child: Text('검색하신 내용에 맞는 상품이없어용'));
+                }
+                return ListView.builder(
+                  itemCount: filteredDocs.length,
+                  itemBuilder: (context, index) {
+                    final doc = filteredDocs[index];
+                    final data = doc.data() as Map<String, dynamic>;
+                    final String postname = data['postName'] ?? 'No title'; // 목록 제목
+                    final String userName = data['userName'] ?? 'Unknown'; // 게시 유저명
+                    final String price = data['productPrice'] ?? '가격정보 없음'; // 목록 가격
+                    final String category = data['category'] ?? 'No category'; // 목록 카테고리
+                    final Timestamp timestamp = data['timestamp'] ?? Timestamp.now();
+                    final String formattedDate =
+                        DateFormat('yyyy-MM-dd').format(timestamp.toDate()); // 게시 날짜
+                    final List<dynamic> imageUrls = data['imageUrls'] ?? []; // 목록 이미지 리스트
+
+
+                    return Card(
+                      child: ListTile(
+                        leading: imageUrls.isNotEmpty
+                            ? Image.network(
+                                imageUrls[0],
+                                width: 50,
+                                height: 50,
+                                fit: BoxFit.cover,
+                                errorBuilder: (context, error, stackTrace) {
+                                  return Icon(Icons.error);
+                                },
+                              )
+                            : null,
+                        title: Text(postname),
+                        subtitle:
+                            Text('by $userName\n$formattedDate\n카테고리 : $category'),
+                        isThreeLine: true,
+                        onTap: () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (context) => ProductDetailPage(
+                                postId: doc.id,
+                              ),
+                            ),
+                          );
+                        },
                       ),
                     );
                   },
-                ),
-              );
-            },
-          );
-        },
+                );
+              },
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/pages/ProductListPage.dart
+++ b/lib/pages/ProductListPage.dart
@@ -1,8 +1,14 @@
+import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:intl/intl.dart';
 
 import 'ProductDetailPage.dart';
+
+//위젯 임포트
+import 'package:amtt/widgets/ProductCard.dart';
+import 'package:amtt/widgets/BtnYesBG.dart';
+import 'package:amtt/widgets/BtnNoBG.dart';
 
 class ProductListPage extends StatefulWidget {
   @override
@@ -75,191 +81,291 @@ class _ProductListPageState extends State<ProductListPage> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: Colors.white,
-      appBar: AppBar(
-        backgroundColor: Colors.white,
-        title: Text('상품 목록'),
-        actions: [
+    return Container(
+      color: Colors.white,
+      child: Padding(
+        padding: EdgeInsets.all(0.04.sw),
+        child: Scaffold(
+          backgroundColor: Colors.white,
+          appBar: AppBar(
+            backgroundColor: Colors.white,
+            title: Text('상품 목록'),
+            actions: [
 
-          IconButton(onPressed: () => {print("알림버튼 클릭")}, icon: Icon(Icons.notifications_rounded), color: Color(0xff4EBDBD),),
+              IconButton(onPressed: () => {print("알림버튼 클릭")}, icon: Icon(Icons.notifications_rounded), color: Color(0xff4EBDBD),),
 
-        ],
-        bottom: PreferredSize(
-          preferredSize: Size.fromHeight(48.0),
-          child: Row(
-            children: [
-              Expanded(
-                child: TextField(
-                  controller: _searchController,
-                  decoration: InputDecoration(
-                    hintText: "검색하세용",
-                    suffixIcon: IconButton(
-                      icon: Icon(Icons.search),
-                      onPressed: () {
+            ],
+            bottom: PreferredSize(
+              preferredSize: Size.fromHeight(48.0),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: TextField(
+                      controller: _searchController,
+                      decoration: InputDecoration(
+                        hintText: "검색하세용",
+                        suffixIcon: IconButton(
+                          icon: Icon(Icons.search),
+                          onPressed: () {
+                            setState(() {
+                              _searchText = _searchController.text;
+                            });
+                          },
+                        ),
+                      ),
+                      onSubmitted: (value) {
                         setState(() {
-                          _searchText = _searchController.text;
+                          _searchText = value;
                         });
                       },
                     ),
                   ),
-                  onSubmitted: (value) {
-                    setState(() {
-                      _searchText = value;
-                    });
-                  },
-                ),
-              ),
-              IconButton(
-                icon: Icon(Icons.filter_list),
-                onPressed: _selectCategory,
-              ),
-            ],
-          ),
-        ),
-      ),
-      body: Column(
-        children: <Widget>[
-
-          // 검색 필드 공간
-          Container(
-            decoration: BoxDecoration(
-              color: Colors.white,
-              border: Border.all(
-                color: Color(0xff4EBDBD),
-                width: 1.0,
-              ),
-              borderRadius: BorderRadius.circular(8.0),
-            ),
-            padding: EdgeInsets.symmetric(horizontal: 12.0),
-            child: Row(
-              children: [
-                Icon(Icons.search, color: Color(0xff4EBDBD)),
-                SizedBox(width: 8.0),
-                Expanded(
-                  child: TextField(
-                    decoration: InputDecoration(
-                      labelText: '목록 검색',
-                      border: InputBorder.none,
-                      labelStyle: TextStyle(color: Color(0xff4EBDBD)),
-                    ),
+                  IconButton(
+                    icon: Icon(Icons.filter_list),
+                    onPressed: _selectCategory,
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
           ),
+          body: Column(
+            children: <Widget>[
 
-          // 검색 필터, 글쓰기 버튼 공간
-          Row(
+              SizedBox(height : 15),
 
-            children: [
-
-              //검색필터 공간
-              Expanded(
-                flex: 2,
-                child: Container(
-
+              // 검색 필드 공간
+              Container(
+                decoration: BoxDecoration(
+                  color: Colors.white,
+                  border: Border.all(
+                    color: Color(0xff4EBDBD),
+                    width: 2.0,
+                  ),
+                  borderRadius: BorderRadius.circular(8.0),
                 ),
+                padding: EdgeInsets.symmetric(horizontal: 12.0),
+                child: Row(
+                  children: [
+                    Icon(Icons.search, color: Color(0xff4EBDBD)),
+                    SizedBox(width: 8.0),
+                    Expanded(
+                      child: TextField(
+                        decoration: InputDecoration(
+                          labelText: '목록 검색',
+                          border: InputBorder.none,
+                          labelStyle: TextStyle(color: Color(0xff4EBDBD)),
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+
+              SizedBox(height: 15,),
+
+              // 검색 필터, 글쓰기 버튼 공간
+              Row(
+
+                children: [
+
+                  //검색필터 공간
+                  Expanded(
+                    flex: 2,
+                    child: Container(
+
+                      child: BtnNoBG(btnText : '검색조건', onPressed: () {
+                        showModalBottomSheet(
+                          context: context,
+                          isScrollControlled: true,
+                          builder: (BuildContext context) {
+                            return BottomSheetContent();
+                          },
+                        );
+                      },
+                      ),
+                    ),
+
+                  ),
+
+                  SizedBox(width: 15,),
+
+                  //글쓰기 버튼 공간
+                  Expanded(
+                    flex: 1,
+                    child: Container(
+
+                      child: BtnYesBG(btnText : '글쓰기', onPressed : () => {
+                        print("검색조건 클릭")
+
+                      }),
+
+                    ),
+
+                  ),
+                ],
 
               ),
 
-              //글쓰기 버튼 공간
+              SizedBox(height: 15,),
+
               Expanded(
-                flex: 1,
-                child: Container(
+                child: StreamBuilder<QuerySnapshot>(
+                  stream: _firestore
+                      .collection('products')
+                      .orderBy('timestamp', descending: true)
+                      .snapshots(),
+                  builder: (context, snapshot) {
+                    if (snapshot.connectionState == ConnectionState.waiting) {
+                      return Center(child: CircularProgressIndicator());
+                    }
+                    if (snapshot.hasError) {
+                      return Center(child: Text('Error: ${snapshot.error}'));
+                    }
+                    if (!snapshot.hasData || snapshot.data!.docs.isEmpty) {
+                      return Center(child: Text('No products found.'));
+                    }
 
-                ),
+                    final filteredDocs = snapshot.data!.docs.where((doc) {
+                      final data = doc.data() as Map<String, dynamic>;
+                      final String postName = data['postName'] ?? 'No title';
+                      final String category = data['category'] ?? '';
 
-              ),
-            ],
+                      final matchesSearchText = _searchText == null ||
+                          _searchText!.isEmpty ||
+                          postName.toLowerCase().contains(_searchText!.toLowerCase());
+                      final matchesCategory = _selectedCategory == null ||
+                          _selectedCategory!.isEmpty ||
+                          category == _selectedCategory;
 
-          ),
+                      return matchesSearchText && matchesCategory;
+                    }).toList();
 
-
-
-          Expanded(
-            child: StreamBuilder<QuerySnapshot>(
-              stream: _firestore
-                  .collection('products')
-                  .orderBy('timestamp', descending: true)
-                  .snapshots(),
-              builder: (context, snapshot) {
-                if (snapshot.connectionState == ConnectionState.waiting) {
-                  return Center(child: CircularProgressIndicator());
-                }
-                if (snapshot.hasError) {
-                  return Center(child: Text('Error: ${snapshot.error}'));
-                }
-                if (!snapshot.hasData || snapshot.data!.docs.isEmpty) {
-                  return Center(child: Text('No products found.'));
-                }
-
-                final filteredDocs = snapshot.data!.docs.where((doc) {
-                  final data = doc.data() as Map<String, dynamic>;
-                  final String postName = data['postName'] ?? 'No title';
-                  final String category = data['category'] ?? '';
-
-                  final matchesSearchText = _searchText == null ||
-                      _searchText!.isEmpty ||
-                      postName.toLowerCase().contains(_searchText!.toLowerCase());
-                  final matchesCategory = _selectedCategory == null ||
-                      _selectedCategory!.isEmpty ||
-                      category == _selectedCategory;
-
-                  return matchesSearchText && matchesCategory;
-                }).toList();
-
-                if (filteredDocs.isEmpty) {
-                  return Center(child: Text('검색하신 내용에 맞는 상품이없어용'));
-                }
-                return ListView.builder(
-                  itemCount: filteredDocs.length,
-                  itemBuilder: (context, index) {
-                    final doc = filteredDocs[index];
-                    final data = doc.data() as Map<String, dynamic>;
-                    final String postname = data['postName'] ?? 'No title'; // 목록 제목
-                    final String userName = data['userName'] ?? 'Unknown'; // 게시 유저명
-                    final String price = data['productPrice'] ?? '가격정보 없음'; // 목록 가격
-                    final String category = data['category'] ?? 'No category'; // 목록 카테고리
-                    final Timestamp timestamp = data['timestamp'] ?? Timestamp.now();
-                    final String formattedDate =
-                        DateFormat('yyyy-MM-dd').format(timestamp.toDate()); // 게시 날짜
-                    final List<dynamic> imageUrls = data['imageUrls'] ?? []; // 목록 이미지 리스트
+                    if (filteredDocs.isEmpty) {
+                      return Center(child: Text('검색하신 내용에 맞는 상품이없어용'));
+                    }
+                    return ListView.builder(
+                      itemCount: filteredDocs.length,
+                      itemBuilder: (context, index) {
+                        final doc = filteredDocs[index];
+                        final data = doc.data() as Map<String, dynamic>;
+                        final String postname = data['postName'] ?? 'No title'; // 목록 제목
+                        final String userName = data['userName'] ?? 'Unknown'; // 게시 유저명
+                        final String price = data['productPrice'] ?? '가격정보 없음'; // 목록 가격
+                        final String category = data['category'] ?? 'No category'; // 목록 카테고리
+                        final Timestamp timestamp = data['timestamp'] ?? Timestamp.now();
+                        final String formattedDate =
+                            DateFormat('yyyy-MM-dd').format(timestamp.toDate()); // 게시 날짜
+                        final List<dynamic> imageUrls = data['imageUrls'] ?? []; // 목록 이미지 리스트
 
 
-                    return Card(
-                      child: ListTile(
-                        leading: imageUrls.isNotEmpty
-                            ? Image.network(
-                                imageUrls[0],
-                                width: 50,
-                                height: 50,
-                                fit: BoxFit.cover,
-                                errorBuilder: (context, error, stackTrace) {
-                                  return Icon(Icons.error);
-                                },
-                              )
-                            : null,
-                        title: Text(postname),
-                        subtitle:
-                            Text('by $userName\n$formattedDate\n카테고리 : $category'),
-                        isThreeLine: true,
-                        onTap: () {
-                          Navigator.push(
-                            context,
-                            MaterialPageRoute(
-                              builder: (context) => ProductDetailPage(
-                                postId: doc.id,
-                              ),
+                        try{
+
+                          return Container(
+                            margin: EdgeInsets.only(bottom: 20), // 카드 아이템 간의 마진
+                            child: ProductCard(
+                              title: postname,
+                              price: price,
+                              date: formattedDate,
+                              //이미지 경로가 없으면 비어있는 거 보냄
+                              imageUrl: imageUrls.firstOrNull ?? '',
+                              userName: userName,
+                              onTap: () {
+                                Navigator.push(context, MaterialPageRoute(
+                                    builder: (context) => ProductDetailPage(
+                                      postId: doc.id,
+                                    ),
+                                ));
+                              },
                             ),
                           );
-                        },
-                      ),
+
+                        }
+                        catch (e, stackTrace)
+                        {
+                          print("에러발생");
+                          print(stackTrace);
+                        }
+
+
+                      },
                     );
                   },
-                );
-              },
-            ),
+                ),
+              ),
+            ],
+          ),
+
+        ),
+      ),
+    );
+  }
+}
+
+
+class BottomSheetContent extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: EdgeInsets.all(16),
+      height: MediaQuery.of(context).size.height * 0.9,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              IconButton(
+                icon: Icon(Icons.arrow_back),
+                onPressed: () {
+                  Navigator.pop(context);
+                },
+              ),
+              Text(
+                '제목',
+                style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+              ),
+              SizedBox(width: 48), // To balance the back button on the left
+            ],
+          ),
+          SizedBox(height: 16),
+          Text('카테고리 선택', style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+          DropdownButton<String>(
+            isExpanded: true,
+            items: <String>['카테고리 1', '카테고리 2', '카테고리 3'].map((String value) {
+              return DropdownMenuItem<String>(
+                value: value,
+                child: Text(value),
+              );
+            }).toList(),
+            onChanged: (_) {},
+          ),
+          SizedBox(height: 16),
+          Text('가격 선택', style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+          Slider(
+            value: 50,
+            min: 0,
+            max: 100,
+            divisions: 10,
+            label: '50',
+            onChanged: (value) {},
+          ),
+          Spacer(),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceAround,
+            children: [
+              ElevatedButton(
+                onPressed: () {
+                  // 초기화 버튼 기능
+                },
+                child: Text('초기화'),
+              ),
+              ElevatedButton(
+                onPressed: () {
+                  // 저장 버튼 기능
+                },
+                child: Text('저장'),
+              ),
+            ],
           ),
         ],
       ),

--- a/lib/pages/ProductListPage.dart
+++ b/lib/pages/ProductListPage.dart
@@ -6,6 +6,7 @@ import 'package:intl/intl.dart';
 // 페이지 임포트
 import 'ProductDetailPage.dart';
 import 'ProductRegisterPage.dart';
+import 'SearchPage.dart';
 
 //위젯 임포트
 import 'package:amtt/widgets/ProductCard.dart';
@@ -77,6 +78,7 @@ class _ProductListPageState extends State<ProductListPage> {
         child: Scaffold(
           backgroundColor: Colors.white,
           appBar: AppBar(
+            scrolledUnderElevation: 0,
             automaticallyImplyLeading: false, // 뒤로가기 버튼 비활성화
             backgroundColor: Colors.white,
             // TODO : 여기 접속한 유저가 선택한 대학에 따라 설정되게 해야함
@@ -84,7 +86,9 @@ class _ProductListPageState extends State<ProductListPage> {
             titleSpacing: 0,
             actions: [
 
-              IconButton(onPressed: () => {print("알림버튼 클릭")}, icon: Icon(Icons.search, size: 30,)),
+              IconButton(onPressed: () => {
+                Navigator.push( context, MaterialPageRoute(
+              builder: (context) => SearchPage()), )}, icon: Icon(Icons.search, size: 30,)),
               IconButton(onPressed: () => {print("알림버튼 클릭")}, icon: Icon(Icons.notifications_none, size: 30,)),
 
             ],
@@ -287,7 +291,7 @@ class _BottomSheetContentState extends State<BottomSheetContent> {
 
           Text('카테고리 선택', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
           SizedBox(height: 16),
-          
+
           // 그리드 카테고리 아이템 공간
           GridView.builder(
             shrinkWrap: true,
@@ -298,8 +302,8 @@ class _BottomSheetContentState extends State<BottomSheetContent> {
               mainAxisSpacing: 25, //위 아래 간격
               childAspectRatio: 1, // 비율, 높을수록 위아래로 납작해짐
             ),
-            
-            
+
+
             itemCount: _categories.length,
             itemBuilder: (context, index) {
               final category = _categories[index];

--- a/lib/pages/SearchPage.dart
+++ b/lib/pages/SearchPage.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:intl/intl.dart';
+
+// 페이지 임포트
+import 'ProductDetailPage.dart';
+
+//위젯 임포트
+import 'package:amtt/widgets/ProductCard.dart';
+
+class SearchPage extends StatefulWidget {
+  @override
+  _SearchPageState createState() => _SearchPageState();
+}
+
+class _SearchPageState extends State<SearchPage> {
+  final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+  final _searchController = TextEditingController(); // 검색 텍스트필드 컨트롤러
+  String? _searchText = '';
+  List<String> _searchHistory = []; // 검색 기록 목록
+
+  @override
+  void initState() {
+    super.initState();
+    // 검색 기록 로드 (옵션)
+  }
+
+
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.all(0.04.sw),
+      child: Scaffold(
+        backgroundColor: Colors.white,
+        appBar: AppBar(
+          backgroundColor: Colors.white,
+          title: TextField(
+            controller: _searchController, // 검색 텍스트필드 컨트롤러 연결
+            autofocus: true, // 자동 포커스 설정
+            onSubmitted: (value) {
+              setState(() {
+                _searchText = value;
+              });
+              // 검색 기능 구현 (옵션)
+            },
+            decoration: InputDecoration(
+              hintText: '검색어를 입력하세요',
+              border: OutlineInputBorder(),
+            ),
+          ),
+          leading: IconButton(
+            icon: Icon(Icons.arrow_back),
+            onPressed: () => Navigator.pop(context), // 뒤로가기 버튼
+          ),
+        ),
+        body: Column(
+          children: [
+            Text('검색기록'),
+
+            Visibility(
+              visible: _searchText!.isNotEmpty,
+              child: Expanded(child: StreamBuilder<QuerySnapshot>(
+                stream: _firestore
+                    .collection('products')
+                    .orderBy('timestamp', descending: true)
+                    .snapshots(),
+                builder: (context, snapshot) {
+                  if (snapshot.connectionState == ConnectionState.waiting) {
+                    return Center(child: CircularProgressIndicator());
+                  }
+                  if (snapshot.hasError) {
+                    return Center(child: Text('Error: ${snapshot.error}'));
+                  }
+                  if (!snapshot.hasData || snapshot.data!.docs.isEmpty) {
+                    return Center(child: Text('No products found.'));
+                  }
+
+                  final filteredDocs = snapshot.data!.docs.where((doc) {
+                    final data = doc.data() as Map<String, dynamic>;
+                    final String postName = data['postName'] ?? 'No title';
+                    final String category = data['category'] ?? '';
+
+                    final matchesSearchText = _searchText == null ||
+                        _searchText!.isEmpty ||
+                        postName.toLowerCase().contains(_searchText!.toLowerCase());
+
+                    return matchesSearchText;
+                  }).toList();
+
+                  if (filteredDocs.isEmpty) {
+                    return Center(child: Text('검색하신 내용에 맞는 상품이없어용'));
+                  }
+                  return ListView.builder(
+                    itemCount: filteredDocs.length,
+                    itemBuilder: (context, index) {
+                      final doc = filteredDocs[index];
+                      final data = doc.data() as Map<String, dynamic>;
+                      final String postname = data['postName'] ?? 'No title'; // 목록 제목
+                      final String userName = data['userName'] ?? 'Unknown'; // 게시 유저명
+                      final String price = data['productPrice'] ?? '가격정보 없음'; // 목록 가격
+                      final String category = data['category'] ?? 'No category'; // 목록 카테고리
+                      final Timestamp timestamp = data['timestamp'] ?? Timestamp.now();
+                      final String formattedDate =
+                      DateFormat('yyyy-MM-dd').format(timestamp.toDate()); // 게시 날짜
+                      final List<dynamic> imageUrls = data['imageUrls'] ?? []; // 목록 이미지 리스트
+
+
+                      try{
+
+                        return Container(
+                          margin: EdgeInsets.only(bottom: 0), // 카드 아이템 간의 마진
+                          child: ProductCard(
+                            title: postname,
+                            price: price,
+                            date: formattedDate,
+                            //이미지 경로가 없으면 비어있는 거 보냄
+                            imageUrl: imageUrls.firstOrNull ?? '',
+                            userName: userName,
+                            onTap: () {
+                              Navigator.push(context, MaterialPageRoute(
+                                builder: (context) => ProductDetailPage(
+                                  postId: doc.id,
+                                ),
+                              ));
+                            },
+                          ),
+                        );
+
+                      }
+                      catch (e, stackTrace)
+                      {
+                        print("에러발생");
+                        print(stackTrace);
+                      }
+
+
+                    },
+                  );
+                },
+              ),
+              ),
+            )
+          ],
+        )
+      ),
+    );
+  }
+}

--- a/lib/pages/WishListPage.dart
+++ b/lib/pages/WishListPage.dart
@@ -74,6 +74,7 @@ class _WishListPageState extends State<WishListPage> {
                 final String postname = data['postName'] ?? 'No title';
                 final String userName = data['userName'] ?? 'Unknown';
                 final String price = data['productPrice'] ?? '가격정보 없음';
+                final String category = data['category'] ?? 'No category'; // 목록 카테고리
                 final Timestamp timestamp = data['timestamp'] ?? Timestamp.now();
                 final String formattedDate =
                 DateFormat('yyyy-MM-dd').format(timestamp.toDate());

--- a/lib/widgets/BtnNoBG.dart
+++ b/lib/widgets/BtnNoBG.dart
@@ -24,7 +24,7 @@ class BtnNoBG extends StatelessWidget {
       ),
       child: Text(
         btnText, // 버튼에 표시할 텍스트
-        style: TextStyle(fontSize: 18.sp), // 텍스트 스타일 설정
+        style: TextStyle(fontSize: 20), // 텍스트 스타일 설정
       ),
     );
   }

--- a/lib/widgets/ProductCard.dart
+++ b/lib/widgets/ProductCard.dart
@@ -49,7 +49,7 @@ class ProductCard extends StatelessWidget {
                     Text(
                       title,
                       style: TextStyle(
-                        fontSize: 18,
+                        fontSize: 16,
                         fontWeight: FontWeight.bold,
                         color: Colors.black,
                       ),
@@ -62,7 +62,7 @@ class ProductCard extends StatelessWidget {
                       style: TextStyle(
                         fontSize: 20,
                         fontWeight: FontWeight.bold,
-                        color: Colors.black,
+                        color: Color(0xff596773),
                       ),
                     ),
                     SizedBox(height: 8),

--- a/lib/widgets/ProductCard.dart
+++ b/lib/widgets/ProductCard.dart
@@ -29,14 +29,19 @@ class ProductCard extends StatelessWidget {
       child: Container(
         decoration: BoxDecoration(
           border: Border(
-            bottom: BorderSide(
-              color: Colors.grey,
-              width: 1.0,
+            top: BorderSide( // 위 테두리
+            color: Color(0xffF7F8F8),
+            width: 1.0,
+            ),
+            bottom: BorderSide( // 아래 테두리
+            color: Color(0xffF7F8F8),
+            width: 1.0,
             ),
           ),
+          borderRadius: BorderRadius.circular(0.0),
         ),
         child: Padding(
-          padding: const EdgeInsets.all(0.0),
+          padding: const EdgeInsets.all(10.0),
           child: Row(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
@@ -62,7 +67,7 @@ class ProductCard extends StatelessWidget {
                       style: TextStyle(
                         fontSize: 20,
                         fontWeight: FontWeight.bold,
-                        color: Color(0xff596773),
+                        color: Color(0xff8ADADA),
                       ),
                     ),
                     SizedBox(height: 8),
@@ -134,8 +139,8 @@ class ProductCard extends StatelessWidget {
                         borderRadius: BorderRadius.circular(8),
                         child: Image.network(
                           imageUrl,
-                          width: 80,
-                          height: 80,
+                          width: 90,
+                          height: 90,
                           fit: BoxFit.cover,
                         ),
                       ),

--- a/lib/widgets/ProductCard.dart
+++ b/lib/widgets/ProductCard.dart
@@ -100,6 +100,7 @@ class ProductCard extends StatelessWidget {
 
                         //TODO : 이 아래는 실제 데이터 여부에 따라 표시되도록, 데이터 없으면 아에 안보이게 해야함
 
+                        /*
                         //찜 갯수
                         Icon(size: 13, color: Colors.grey,Icons.favorite),
                         Text(
@@ -120,7 +121,7 @@ class ProductCard extends StatelessWidget {
                             fontSize: 16,
                             color: Colors.grey,
                           ),
-                        ),
+                        ),*/
 
                       ],
                     )


### PR DESCRIPTION
### 작업 내용
ProductListPage 페이지 UI 작업을 하였습니다. 검색은 검색 페이지를 만들어서 분리했습니다.
목록뷰 리스트에 이전에 제작한 카드 위젯을 적용시켰습니다. 상단 버튼 모음 공간(검색조건,글쓰기) 추가 
및 카테고리 버튼 클릭시 떠오르는 bottomsheetContent UI 적용했습니다.

기타 세부 변경사항은 커밋을 확인해주세요

웹 / 안드로이드(픽셀8프로, 갤럭시 s23) 환경에서 테스트 했습니다.
