### PR TITLE
# design:채팅 페이지 UI 작업

### DIFF
--- a/lib/pages/ChatPage.dart
+++ b/lib/pages/ChatPage.dart
@@ -11,10 +11,6 @@ import 'package:flutter/foundation.dart' show kIsWeb;
 
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 
-//위젯 임포트
-import 'package:amtt/widgets/BtnNoBG.dart';
-import 'package:amtt/widgets/BtnYesBG.dart';
-
 class ChatPage extends StatelessWidget {
   final String chatRoomId;
   final TextEditingController _controller = TextEditingController();
@@ -73,6 +69,40 @@ class ChatPage extends StatelessWidget {
 
           body: Column(
             children: [
+
+              SizedBox(height: 10,),
+
+              //게시글 확인하러 가기 공간
+              Material(
+                color: Color(0xFFDCF2F2),
+                borderRadius: BorderRadius.circular(12),
+                child: InkWell(
+                  onTap: () => {
+                    
+                    //TODO : 여기에 게시글 확인하러 가는 코드 넣어야함
+                    
+                  },
+                  highlightColor: Colors.grey.withOpacity(0.1), //길게 누를 때 색상
+                  splashColor: Colors.grey.withOpacity(0.2), //탭 했을 때 잉크 효과 색상
+                  child: Container(
+                    padding: EdgeInsets.symmetric(vertical: 16.0, horizontal: 32.0),
+                    child: Center(
+                      child: Text(
+                        '게시글 확인하러 가기',
+                        style: TextStyle(
+                          color: Color(0xFF4EBDBD), // 텍스트 색
+                          fontSize: 18.0,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+
+              SizedBox(height: 15,),
+
+
               Expanded(
                 child: StreamBuilder(
                   stream: FirebaseFirestore.instance

--- a/lib/pages/ChatPage.dart
+++ b/lib/pages/ChatPage.dart
@@ -11,6 +11,10 @@ import 'package:flutter/foundation.dart' show kIsWeb;
 
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 
+//위젯 임포트
+import 'package:amtt/widgets/BtnNoBG.dart';
+import 'package:amtt/widgets/BtnYesBG.dart';
+
 class ChatPage extends StatelessWidget {
   final String chatRoomId;
   final TextEditingController _controller = TextEditingController();
@@ -25,7 +29,20 @@ class ChatPage extends StatelessWidget {
     void _showBottomSheet() {
       showModalBottomSheet(
           context: context,
-          builder: (BuildContext context) => BottomSheetContent()
+        builder: (BuildContext context) {
+          // 키보드 높이를 가져옵니다.
+          final keyboardHeight = MediaQuery.of(context).viewInsets.bottom;
+
+          print('키보드 높이 : ');
+          print(keyboardHeight);
+
+          // BottomSheet의 높이를 키보드 높이 또는 최소 높이 중 큰 값으로 설정합니다.
+          final sheetHeight = 200.0;
+          return Container(
+            height: sheetHeight,
+            child: BottomSheetContent(imagePressed: _sendImages),
+          );
+        },
       );
     }
 
@@ -35,10 +52,15 @@ class ChatPage extends StatelessWidget {
         padding: EdgeInsets.symmetric(horizontal: 0.06.sw, vertical: 10),
         child: Scaffold(
           backgroundColor: Colors.white,
+
+          //앱바
           appBar: AppBar(
+            scrolledUnderElevation: 0, // 스크롤시 색상 변경 방지
             backgroundColor: Colors.white,
-            title: Text('Chat Room'),
+            title: Text('채팅방'),
             actions: [
+
+              // 채팅방 나가기 버튼
               IconButton(
                   icon: Icon(Icons.exit_to_app),
                   onPressed: () async {
@@ -47,6 +69,8 @@ class ChatPage extends StatelessWidget {
                   }),
             ],
           ),
+
+
           body: Column(
             children: [
               Expanded(
@@ -153,31 +177,78 @@ class ChatPage extends StatelessWidget {
                 ),
               ),
 
+              SizedBox(height: 25,),
+
 
               //채팅 입력 바 공간
-              Padding(
-                padding: const EdgeInsets.all(8.0),
-                child: Row(
-                  children: [
-                    IconButton(
-                      icon: Icon(Icons.image),
-                      onPressed: _showBottomSheet,
-                    ),
-                    Expanded(
-                      child: TextField(
-                        controller: _controller,
-                        decoration: InputDecoration(
-                          hintText: 'Enter your message',
+              Container(
+                child: Padding(
+                  padding: const EdgeInsets.all(0.0),
+                  child: Row(
+                    children: [
+                      // 맨 왼쪽 버튼 변경 (플러스 기호)
+                      IconButton(
+                        icon: Icon(Icons.add), // 플러스 기호 아이콘
+                        onPressed: _showBottomSheet,
+                      ),
+
+                      SizedBox(width: 5,),
+
+                      // 메시지 입력창
+                      Expanded(
+                        flex: 4,
+                        child: TextField(
+                          controller: _controller,
+                          onSubmitted: (value) {
+                            _sendMessage();
+                          },
+                          decoration: InputDecoration(
+                            hintText: '메시지 입력',
+                            // 둥근 모서리 및 초록색 테두리 추가
+                            border: OutlineInputBorder(
+                              borderRadius: BorderRadius.circular(12), // 원하는 곡률 조절
+                              borderSide: BorderSide(
+                                width: 2, // 테두리 두께 조절
+                              ),
+                            ),
+                            focusedBorder: OutlineInputBorder( // 활성화 시 테두리 설정
+                              borderRadius: BorderRadius.circular(12),
+                              borderSide: BorderSide(
+                                color: Color(0xff4EBDBD), // 활성화 시 테두리 색상
+                              ),
+                            ),
+                          ),
                         ),
                       ),
-                    ),
-                    IconButton(
-                      icon: Icon(Icons.send),
-                      onPressed: _sendMessage,
-                    ),
-                  ],
+
+                      SizedBox(width: 10,),
+
+                      //메시지 전송버튼
+                      Expanded(
+                          flex: 1,
+                        child: ElevatedButton(
+                          onPressed: _sendMessage,
+                          style: ElevatedButton.styleFrom(
+                            minimumSize: Size.fromHeight(55),
+                            foregroundColor: Colors.white, backgroundColor: Color(0xFF4EBDBD), // 글자색은 하얀색
+                            padding: EdgeInsets.symmetric(horizontal: 0.01.sh, vertical: 0.01.sw), // 버튼 안의 패딩 설정
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(12.0), // 모서리 둥글게
+                            ),
+                          ),
+                          child: Text(
+                            '전송', // 버튼에 표시할 텍스트
+                            style: TextStyle(fontSize: 20), // 텍스트 스타일 설정
+                          ),
+                        )
+                      ),
+
+                    ],
+                  ),
                 ),
               ),
+
+
             ],
           ),
         ),
@@ -281,8 +352,12 @@ class ChatPage extends StatelessWidget {
 }
 
 
-// 하단에서 올라오는 결과 필터 다이얼로그창
+// 하단에서 올라오는 추가 기능 다이얼로그창
 class BottomSheetContent extends StatelessWidget {
+  final VoidCallback imagePressed; // 이미지 클릭 이벤트
+  //final VoidCallback mapPressed;
+
+  const BottomSheetContent({super.key, required this.imagePressed});
 
   @override
   Widget build(BuildContext context) {
@@ -309,14 +384,75 @@ class BottomSheetContent extends StatelessWidget {
             ],
           ),
 
+
+          //아이템 버튼 공간
           SizedBox(height: 26),
 
-          //
+          // 아이템 버튼 공간
+          Wrap(
+            spacing: 24, // 버튼 간 간격
+            runSpacing: 16, // 행 간 간격
+            children: [
 
-          SizedBox(height: 16),
+              Column(
+
+                children: [
 
 
+                  //이미지 전송 버튼
+                  ElevatedButton(
+                    onPressed: () {
+                      imagePressed();
+                      print("이거 실행");
+                    },
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Color(0xff4EBDBD),
+                      shape: CircleBorder(),
+                      padding: EdgeInsets.all(20),
+                    ),
+                    child: Icon(
+                      Icons.image,
+                      color: Colors.white,
+                      size: 24,
+                    ),
+                  ),
 
+                  SizedBox(height: 5,),
+
+                  Text('이미지 전송'),
+                ],
+
+              ),
+
+
+              Column(
+                children: [
+
+                  // 지도 버튼 -- 미구현시 삭제
+                  ElevatedButton(
+                    onPressed: () {
+                      // 버튼 클릭 시 처리 코드
+                    },
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Color(0xff4EBDBD),
+                      shape: CircleBorder(),
+                      padding: EdgeInsets.all(20),
+                    ),
+                    child: Icon(
+                      Icons.map,
+                      color: Colors.white,
+                      size: 24,
+                    ),
+                  ),
+
+                  SizedBox(height: 5,),
+
+                  Text('내 위치 전송'),
+                ],
+              ),
+
+            ],
+          ),
 
 
         ],

--- a/lib/pages/ChatRoomsPage.dart
+++ b/lib/pages/ChatRoomsPage.dart
@@ -4,6 +4,9 @@ import 'package:flutter/material.dart';
 import 'ChatPage.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 
+//위젯 임포트
+import 'package:amtt/widgets/ChatListCard.dart';
+
 class ChatRoomsPage extends StatefulWidget {
   @override
   _ChatRoomsPageState createState() => _ChatRoomsPageState();
@@ -13,92 +16,142 @@ class _ChatRoomsPageState extends State<ChatRoomsPage> {
   final FirebaseAuth _auth = FirebaseAuth.instance;
   final FirebaseFirestore _firestore = FirebaseFirestore.instance;
 
+  User? currentUser = FirebaseAuth.instance.currentUser;
+
+
   @override
   Widget build(BuildContext context) {
-    return Container(
-      color: Colors.white,
-      child: Padding(
-        padding: EdgeInsets.symmetric(horizontal: 0.06.sw, vertical: 10),
-        child: Scaffold(
-          backgroundColor: Colors.white,
-          appBar: AppBar(
+
+    print('안녕하세요');
+    print(currentUser);
+
+    if(currentUser != null) {
+      return Container(
+        color: Colors.white,
+        child: Padding(
+          padding: EdgeInsets.symmetric(horizontal: 0.06.sw, vertical: 10),
+          child: Scaffold(
             backgroundColor: Colors.white,
-            title: Text('Chat Rooms'),
-          ),
-          body: StreamBuilder<QuerySnapshot>(
-            stream: _firestore
-                .collection('chat_participants')
-                .where('user_id', isEqualTo: _auth.currentUser!.uid)
-                .where('left_at', isNull: true)
-                .snapshots(),
-            builder: (context, snapshot) {
-              if (snapshot.hasError) {
-                return Center(
-                  child: Text('Something went wrong'),
-                );
-              }
 
-              if (snapshot.connectionState == ConnectionState.waiting) {
-                return Center(
-                  child: CircularProgressIndicator(),
-                );
-              }
+            appBar: AppBar(
+              backgroundColor: Colors.white,
+              title: Text('채팅 목록'),
+            ),
 
-              if (snapshot.data!.docs.isEmpty) {
-                return Center(
-                  child: Text('No chat rooms found'),
-                );
-              }
 
-              return ListView.builder(
-                itemCount: snapshot.data!.docs.length,
-                itemBuilder: (context, index) {
-                  DocumentSnapshot document = snapshot.data!.docs[index];
-                  String chatRoomId = document['room_id'];
-
-                  // 채팅방 이름을 가져오기 위해 스트림 사용
-                  return StreamBuilder<DocumentSnapshot>(
-                    stream: _firestore.collection('chat_rooms').doc(chatRoomId).snapshots(),
-                    builder: (context, chatRoomSnapshot) {
-                      if (chatRoomSnapshot.hasError) {
-                        return ListTile(
-                          title: Text('Error loading chat room name'),
-                        );
-                      }
-
-                      if (chatRoomSnapshot.connectionState == ConnectionState.waiting) {
-                        return ListTile(
-                          title: Text('Loading chat room name...'),
-                        );
-                      }
-
-                      if (chatRoomSnapshot.data != null) {
-                        String chatRoomName = chatRoomSnapshot.data!['name'];
-                        return ListTile(
-                          title: Text(chatRoomName),
-                          onTap: () {
-                            // Navigate to the chat room page
-                            Navigator.push(
-                              context,
-                              MaterialPageRoute(
-                                builder: (context) => ChatPage(chatRoomId),
-                              ),
-                            );
-                          },
-                        );
-                      } else {
-                        return ListTile(
-                          title: Text('Chat room name not found'),
-                        );
-                      }
-                    },
+            body: StreamBuilder<QuerySnapshot>(
+              stream: _firestore
+                  .collection('chat_participants')
+                  .where('user_id', isEqualTo: _auth.currentUser!.uid)
+                  .where('left_at', isNull: true)
+                  .snapshots(),
+              builder: (context, snapshot) {
+                if (snapshot.hasError) {
+                  return Center(
+                    child: Text('오류 발생'),
                   );
-                },
-              );
-            },
+                }
+
+                if (snapshot.connectionState == ConnectionState.waiting) {
+                  return Center(
+                    child: CircularProgressIndicator(),
+                  );
+                }
+
+                if (snapshot.data!.docs.isEmpty) {
+                  return Center(
+                    child: Text('채팅방 없음'),
+                  );
+                }
+
+                // 채팅 목록 리스트 뷰 빌더
+                return ListView.builder(
+                  itemCount: snapshot.data!.docs.length,
+                  itemBuilder: (context, index) {
+                    DocumentSnapshot document = snapshot.data!.docs[index];
+                    String chatRoomId = document['room_id'];
+
+                    // 채팅방 이름을 가져오기 위해 스트림 사용
+                    return StreamBuilder<DocumentSnapshot>(
+                      stream: _firestore.collection('chat_rooms').doc(chatRoomId).snapshots(),
+                      builder: (context, chatRoomSnapshot) {
+                        if (chatRoomSnapshot.hasError) {
+                          return ListTile(
+                            title: Text('채팅방을 불러오던 중 에러가 발생하였습니다.'),
+                          );
+                        }
+
+                        if (chatRoomSnapshot.connectionState == ConnectionState.waiting) {
+                          return ListTile(
+                            title: Text('채팅 방 불러오는 중...'),
+                          );
+                        }
+
+                        // 채팅방 데이터가 있을 때
+                        if (chatRoomSnapshot.data != null) {
+                          String chatRoomName = chatRoomSnapshot.data!['name'];
+
+                          //TODO : 아래에 실제값 들어가도록 해야함
+                          return ChatListcard(
+                            userName: chatRoomName,
+                            lastChat: '안녕하세요!',
+                            profileImageUrl: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTKK2tS5TKEY9O_T4S_YCHES2zZhosMgKWt0A&s',
+                            lastTime: '1분전',
+                            notiCount: '2',
+                            onTap: () => {
+
+                              // 해당 채팅방으로 넘어가는 기능
+                              Navigator.push(
+                                context,
+                                MaterialPageRoute(
+                                  builder: (context) => ChatPage(chatRoomId),
+                                ),
+                              )
+                            },
+                          );
+                        } else {
+                          return ListTile(
+                            title: Text('Chat room name not found'),
+                          );
+                        }
+                      },
+                    );
+                  },
+                );
+              },
+            ),
           ),
         ),
-      ),
-    );
+      );
+    }
+    else {
+      return Container(
+        color: Colors.white,
+        child: Padding(
+          padding: EdgeInsets.symmetric(horizontal: 0.06.sw, vertical: 10),
+          child: Scaffold (
+
+            backgroundColor: Colors.white,
+
+            appBar: AppBar(
+              scrolledUnderElevation: 0,
+              automaticallyImplyLeading: false, // 뒤로가기 버튼 비활성화
+              backgroundColor: Colors.white,
+              title: Text('채팅 목록'),
+            ),
+
+            body: Center(
+              child: Text(
+                '로그인이 필요한 기능입니다'
+              ),
+            ),
+
+          ),
+        ),
+
+      );
+    }
+
+
   }
 }

--- a/lib/pages/ChatRoomsPage.dart
+++ b/lib/pages/ChatRoomsPage.dart
@@ -2,6 +2,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'ChatPage.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
 
 class ChatRoomsPage extends StatefulWidget {
   @override
@@ -14,81 +15,89 @@ class _ChatRoomsPageState extends State<ChatRoomsPage> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: Text('Chat Rooms'),
-      ),
-      body: StreamBuilder<QuerySnapshot>(
-        stream: _firestore
-            .collection('chat_participants')
-            .where('user_id', isEqualTo: _auth.currentUser!.uid)
-            .where('left_at', isNull: true)
-            .snapshots(),
-        builder: (context, snapshot) {
-          if (snapshot.hasError) {
-            return Center(
-              child: Text('Something went wrong'),
-            );
-          }
+    return Container(
+      color: Colors.white,
+      child: Padding(
+        padding: EdgeInsets.symmetric(horizontal: 0.06.sw, vertical: 10),
+        child: Scaffold(
+          backgroundColor: Colors.white,
+          appBar: AppBar(
+            backgroundColor: Colors.white,
+            title: Text('Chat Rooms'),
+          ),
+          body: StreamBuilder<QuerySnapshot>(
+            stream: _firestore
+                .collection('chat_participants')
+                .where('user_id', isEqualTo: _auth.currentUser!.uid)
+                .where('left_at', isNull: true)
+                .snapshots(),
+            builder: (context, snapshot) {
+              if (snapshot.hasError) {
+                return Center(
+                  child: Text('Something went wrong'),
+                );
+              }
 
-          if (snapshot.connectionState == ConnectionState.waiting) {
-            return Center(
-              child: CircularProgressIndicator(),
-            );
-          }
+              if (snapshot.connectionState == ConnectionState.waiting) {
+                return Center(
+                  child: CircularProgressIndicator(),
+                );
+              }
 
-          if (snapshot.data!.docs.isEmpty) {
-            return Center(
-              child: Text('No chat rooms found'),
-            );
-          }
+              if (snapshot.data!.docs.isEmpty) {
+                return Center(
+                  child: Text('No chat rooms found'),
+                );
+              }
 
-          return ListView.builder(
-            itemCount: snapshot.data!.docs.length,
-            itemBuilder: (context, index) {
-              DocumentSnapshot document = snapshot.data!.docs[index];
-              String chatRoomId = document['room_id'];
+              return ListView.builder(
+                itemCount: snapshot.data!.docs.length,
+                itemBuilder: (context, index) {
+                  DocumentSnapshot document = snapshot.data!.docs[index];
+                  String chatRoomId = document['room_id'];
 
-              // 채팅방 이름을 가져오기 위해 스트림 사용
-              return StreamBuilder<DocumentSnapshot>(
-                stream: _firestore.collection('chat_rooms').doc(chatRoomId).snapshots(),
-                builder: (context, chatRoomSnapshot) {
-                  if (chatRoomSnapshot.hasError) {
-                    return ListTile(
-                      title: Text('Error loading chat room name'),
-                    );
-                  }
-
-                  if (chatRoomSnapshot.connectionState == ConnectionState.waiting) {
-                    return ListTile(
-                      title: Text('Loading chat room name...'),
-                    );
-                  }
-
-                  if (chatRoomSnapshot.data != null) {
-                    String chatRoomName = chatRoomSnapshot.data!['name'];
-                    return ListTile(
-                      title: Text(chatRoomName),
-                      onTap: () {
-                        // Navigate to the chat room page
-                        Navigator.push(
-                          context,
-                          MaterialPageRoute(
-                            builder: (context) => ChatPage(chatRoomId),
-                          ),
+                  // 채팅방 이름을 가져오기 위해 스트림 사용
+                  return StreamBuilder<DocumentSnapshot>(
+                    stream: _firestore.collection('chat_rooms').doc(chatRoomId).snapshots(),
+                    builder: (context, chatRoomSnapshot) {
+                      if (chatRoomSnapshot.hasError) {
+                        return ListTile(
+                          title: Text('Error loading chat room name'),
                         );
-                      },
-                    );
-                  } else {
-                    return ListTile(
-                      title: Text('Chat room name not found'),
-                    );
-                  }
+                      }
+
+                      if (chatRoomSnapshot.connectionState == ConnectionState.waiting) {
+                        return ListTile(
+                          title: Text('Loading chat room name...'),
+                        );
+                      }
+
+                      if (chatRoomSnapshot.data != null) {
+                        String chatRoomName = chatRoomSnapshot.data!['name'];
+                        return ListTile(
+                          title: Text(chatRoomName),
+                          onTap: () {
+                            // Navigate to the chat room page
+                            Navigator.push(
+                              context,
+                              MaterialPageRoute(
+                                builder: (context) => ChatPage(chatRoomId),
+                              ),
+                            );
+                          },
+                        );
+                      } else {
+                        return ListTile(
+                          title: Text('Chat room name not found'),
+                        );
+                      }
+                    },
+                  );
                 },
               );
             },
-          );
-        },
+          ),
+        ),
       ),
     );
   }

--- a/lib/pages/ProductDetailPage.dart
+++ b/lib/pages/ProductDetailPage.dart
@@ -233,6 +233,12 @@ class ProductDetailPage extends StatelessWidget {
                                       style: TextStyle(
                                           fontSize: 17, fontWeight: FontWeight.w600)),
 
+
+                                  Spacer(),
+
+                                  // 판매상태 표시 드롭다운 위젯
+                                  CustomDropdown(),
+
                                   Spacer(),
 
                                   Text('$university'),
@@ -469,6 +475,48 @@ class _FavoriteButtonState extends State<FavoriteButton> {
       color: Color(0xFF4EBDBD),
       icon: Icon(
         isZZim ? Icons.favorite : Icons.favorite_border,
+      ),
+    );
+  }
+}
+
+
+// 커스텀 드롭다운 버튼
+class CustomDropdown extends StatefulWidget {
+
+  // TODO : 외부에서 값 넣어주려면 아래처럼 선언해서 selectedValue = widget.postID 이런식으로 사용하면됨
+  //final String postId;
+  //const CustomDropdown({Key? key, required this.postId}) : super(key: key);
+
+  @override
+  _CustomDropdownState createState() => _CustomDropdownState();
+}
+
+class _CustomDropdownState extends State<CustomDropdown> {
+  String selectedValue = '판매중'; // 초기값 설정
+
+  @override
+  Widget build(BuildContext context) {
+    return DropdownButtonHideUnderline(  // 밑줄 제거
+      child: DropdownButton<String>(
+        value: selectedValue,
+        dropdownColor: Colors.white, // 드롭다운 배경색
+        style: TextStyle(color: Colors.black), // 드롭다운 내부 텍스트 색상
+        items: <String>['판매중', '예약중', '판매완료']
+            .map<DropdownMenuItem<String>>((String value) {
+          return DropdownMenuItem<String>(
+            value: value,
+            child: Text(
+              value,
+              style: TextStyle(color: Colors.black), // 각 아이템의 텍스트 색상을 흰색으로 설정S
+            ),
+          );
+        }).toList(),
+        onChanged: (String? newValue) {
+          setState(() {
+            selectedValue = newValue!;
+          });
+        },
       ),
     );
   }

--- a/lib/widgets/ChatListCard.dart
+++ b/lib/widgets/ChatListCard.dart
@@ -1,0 +1,144 @@
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter/material.dart';
+
+class ChatListcard extends StatelessWidget {
+  final String userName; // 상대방 이름
+  final String lastChat; // 가장 최근 대화 내용
+  final String profileImageUrl; // 상대방 프로필 이미지
+  final String lastTime; // 최근 대화일시
+  final String notiCount; // 알림 갯수 - 안 읽은 대화 갯수
+
+  final VoidCallback? onTap;
+
+  const ChatListcard({
+    Key? key,
+    required this.userName,
+    required this.lastChat,
+    required this.profileImageUrl,
+    required this.lastTime,
+    required this.notiCount,
+    this.onTap,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell( //카드 색상 효과 위한 위젯
+      onTap: onTap, //클릭 이벤트
+      highlightColor: Colors.grey.withOpacity(0.1), //길게 누를 때 색상
+      splashColor: Colors.grey.withOpacity(0.2), //탭 했을 때 잉크 효과 색상
+      child: Container(
+        decoration: BoxDecoration(
+          border: Border(
+            top: BorderSide( // 위 테두리
+              color: Color(0xffF7F8F8),
+              width: 1.0,
+            ),
+            bottom: BorderSide( // 아래 테두리
+              color: Color(0xffF7F8F8),
+              width: 1.0,
+            ),
+          ),
+          borderRadius: BorderRadius.circular(0.0),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(10.0),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+
+              // 프로필 이미지 공간
+              Container(
+                width: 60,
+                height: 60,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  image: profileImageUrl.isNotEmpty
+                      ? DecorationImage(
+                    image: NetworkImage(profileImageUrl),
+                    fit: BoxFit.cover,
+                  )
+                      : null,
+                ),
+                child: profileImageUrl.isEmpty
+                    ? Icon(
+                  Icons.account_circle_rounded,
+                  size: 60,
+                  color: Colors.grey,
+                )
+                    : null,
+              ),
+
+              SizedBox(width: 10),
+
+              // 텍스트 데이터 공간
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    // 상대방 이름 텍스트
+                    Text(
+                      userName,
+                      style: TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.bold,
+                        color: Colors.black,
+                      ),
+                    ),
+
+                    SizedBox(height: 8),
+
+                    // 최근 채팅 내용 텍스트
+                    Text(
+                      lastChat,
+                      style: TextStyle(
+                        fontSize: 14,
+                        color: Colors.grey,
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
+                ),
+              ),
+
+              SizedBox(width: 10),
+
+              // 최근 채팅 시간 공간
+              Column(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Text(
+                    lastTime,
+                    style: TextStyle(
+                      fontSize: 12,
+                      color: Colors.grey,
+                    ),
+                  ),
+
+                  SizedBox(height: 3,),
+
+                  // 채팅 안 읽은 거 알림 갯수
+                  if (notiCount.isNotEmpty && int.parse(notiCount) > 0) //내용이 비어있지 않고 0보다 크면
+                    Container(
+                      padding: EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                      decoration: BoxDecoration(
+                        color: Colors.red,
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      child: Text(
+                        notiCount,
+                        style: TextStyle(
+                          fontSize: 12,
+                          color: Colors.white,
+                        ),
+                      ),
+                    ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
### 작업 내용
채팅 목록 페이지와 채팅 페이지 UI 작업을 하였습니다.
목록 카드 UI 위젯을 만들어서 적용하였고 채팅 페이지에서는 게시글 확인하러 가기 버튼을 추가(기능X)  하였습니다
요청에 따라 상세페이지 내에 판매상태 드롭다운 박스를 추가하였습니다.
로그인 여부에 따른 페이지 출력이 다르게 나오게 했습니다.(로그인X -> 로그인이 필요한 기능입니다 뜨도록)

웹 / 안드로이드(픽셀8프로) 환경에서 테스트 했습니다.